### PR TITLE
Update mmaptwo library 202409

### DIFF
--- a/mmaptwo-plus/CMakeLists.txt
+++ b/mmaptwo-plus/CMakeLists.txt
@@ -8,7 +8,7 @@ option(BUILD_SHARED_LIBS "Enable shared library construction.")
 set(MMAPTWO_PLUS_OS CACHE STRING "Target memory mapping API.")
 
 add_library(mmaptwo_plus "mmaptwo.cpp" "mmaptwo.hpp")
-target_compile_features(mmaptwo_plus PRIVATE
+target_compile_features(mmaptwo_plus PUBLIC
     cxx_override cxx_nullptr cxx_constexpr cxx_noexcept
   )
 if (MMAPTWO_PLUS_OS GREATER -1)

--- a/mmaptwo-plus/mmaptwo.cpp
+++ b/mmaptwo-plus/mmaptwo.cpp
@@ -6,8 +6,9 @@
 #define MMAPTWO_PLUS_WIN32_DLL_INTERNAL
 #define _POSIX_C_SOURCE 200809L
 #include "mmaptwo.hpp"
-#include <cstdlib>
 #include <stdexcept>
+#include <new>
+#include <cstdlib>
 #include <cerrno>
 
 namespace mmaptwo {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ option(TCMPLX_ACCESS_P_BUILD_TESTS "build some tests" ON)
 if (TCMPLX_ACCESS_P_BUILD_TESTS)
 add_library(munit_plus STATIC
   munit-plus/munit.cpp munit-plus/munit.hpp)
+target_compile_features(munit_plus PUBLIC cxx_noexcept cxx_constexpr)
 add_library(tcmplx_accessP_testfont STATIC
   testfont.cpp testfont.hpp)
 target_link_libraries(tcmplx_accessP_testfont mmaptwo_plus munit_plus)


### PR DESCRIPTION
This merge request updates the `mmaptwo` library to the latest commit. In addition, this request modifies the test CMake project file in order to repair the macOS build. 

Closes #8.